### PR TITLE
Previous `V8Debugger` links in `chromedebugger` was incorrect and the…

### DIFF
--- a/debuggers/chrome/chromedebugger.js
+++ b/debuggers/chrome/chromedebugger.js
@@ -31,8 +31,8 @@ define(function(require, exports, module) {
         var Variable = require("../../data/variable");
         var Scope = require("../../data/scope");
         
-        var V8Debugger = require("./lib/V8Debugger");
-        var V8DebuggerService = require("./lib/StandaloneV8DebuggerService");
+        var V8Debugger = require("../v8/lib/V8Debugger");
+        var V8DebuggerService = require("../v8/lib/StandaloneV8DebuggerService");
 
         /***** Initialization *****/
         


### PR DESCRIPTION
… IDE failed to load at all. This fix at least enables the IDE to load, chrome debugger does not work.

https://github.com/c9/core/blob/master/configs/client-default.js#L363 is changed to `packagePath: "plugins/c9.ide.run.debug/debuggers/chrome/chromedebugger",` for switching to load the chrome debugger.
