### PR TITLE
GDB Debugger version 2

### DIFF
--- a/debuggers/gdb/gdbdebugger.js
+++ b/debuggers/gdb/gdbdebugger.js
@@ -289,7 +289,6 @@ define(function(require, exports, module) {
             socket = s;
 
             socket.on("back", function() {
-                console.log("gdbdebugger: socket's back");
                 reconnectSync();
             }, plugin);
 
@@ -308,7 +307,6 @@ define(function(require, exports, module) {
 
             // notify all callbacks that debug session has ended
             socket.on("end", function() {
-                console.log("gdbdebugger went away");
                 for (var id in callbacks) {
                     if (!callbacks.hasOwnProperty(id) || !callbacks[id])
                         continue;

--- a/debuggers/gdb/gdbdebugger.js
+++ b/debuggers/gdb/gdbdebugger.js
@@ -243,16 +243,23 @@ define(function(require, exports, module) {
         /***** Methods *****/
 
         function getProxySource(process){
-            var bin = process.runner[0].executable;
             var max_depth = (process.runner[0].maxdepth) ?
                             process.runner[0].maxdepth : 50;
+
+            var bin;
+            try {
+                bin = process.insertVariables(process.runner[0].executable);
+            }
+            catch(e) {
+                bin = "!";
+            }
 
             return PROXY
                 .replace(/\/\/.*/g, "")
                 .replace(/[\n\r]/g, "")
                 .replace(/\{PATH\}/, c9.workspaceDir)
                 .replace(/\{MAX_DEPTH\}/, max_depth)
-                .replace(/\{BIN\}/, process.insertVariables(bin))
+                .replace(/\{BIN\}/, bin)
                 .replace(/\{PORT\}/, process.runner[0].debugport);
         }
 
@@ -276,7 +283,7 @@ define(function(require, exports, module) {
                 emit("error", err);
             }, plugin);
 
-            socket.on('connect', function() {
+            socket.on("connect", function() {
                 console.log("gdbdebugger: socket connect");
             }, plugin);
 

--- a/debuggers/gdb/gdbdebugger.js
+++ b/debuggers/gdb/gdbdebugger.js
@@ -497,11 +497,11 @@ define(function(require, exports, module) {
         function evaluate(expression, frame, global, disableBreak, callback) {
             sendCommand("eval", { exp: expression }, function(err, reply) {
                 if (err)
-                    return callback && callback(err);
-                else if (typeof reply.status !== "undefined")
-                    return callback && callback(new Error(reply.status.msg));
+                    return callback(err);
+                else if (typeof reply.status === "undefined")
+                    return callback(new Error(reply.status.msg));
 
-                callback && callback(null, new Variable({
+                callback(null, new Variable({
                     name: expression,
                     value: reply.status.value,
                     type: "number", /* other types produce JS errors */

--- a/debuggers/gdb/gdbdebugger.js
+++ b/debuggers/gdb/gdbdebugger.js
@@ -76,6 +76,9 @@ define(function(require, exports, module) {
         function buildScopeVariables(frame_vars, scope_index, frame_index, vars) {
             function buildVariable(variable, scope) {
                 var props = null;
+
+                if (variable == null) return;
+
                 if (variable.hasOwnProperty("children")) {
                     props = [];
                     variable.children.forEach(function(child) {

--- a/debuggers/gdb/gdbdebugger.js
+++ b/debuggers/gdb/gdbdebugger.js
@@ -413,13 +413,10 @@ define(function(require, exports, module) {
             if (!socket)
                 return;
 
-            btnResume.$ext.style.display = "inline-block";
-            btnSuspend.$ext.style.display = "none";
-            btnSuspend.setAttribute("disabled", false);
-            btnStepOut.setAttribute("disabled", false);
-            btnStepInto.setAttribute("disabled", false);
-            btnStepOver.setAttribute("disabled", false);
+            // notify gdb it should shut down
+            sendCommand("detach");
 
+            // clean up without waiting for gdb to shut down
             if (reader)
                 reader.destroy();
 
@@ -430,6 +427,14 @@ define(function(require, exports, module) {
             emit("frameActivate", {frame: null});
             setState(null);
             emit("detach");
+
+            btnResume.$ext.style.display = "inline-block";
+            btnSuspend.$ext.style.display = "none";
+            btnSuspend.setAttribute("disabled", false);
+            btnStepOut.setAttribute("disabled", false);
+            btnStepInto.setAttribute("disabled", false);
+            btnStepOver.setAttribute("disabled", false);
+
         }
 
         /*

--- a/debuggers/gdb/gdbdebugger.js
+++ b/debuggers/gdb/gdbdebugger.js
@@ -572,17 +572,18 @@ define(function(require, exports, module) {
                 if (err)
                     return callback && callback(err);
 
-                callback(null, reply.BreakpointTable.body.map(function (bp) {
+                var bps = reply.status.BreakpointTable.body.map(function (bp) {
                     return new Breakpoint({
                         id: bp.number,
                         path: bp.fullname,
                         line: parseInt(bp.line, 10)-1,
-                        ignoreCount: (bp.hasOwnProperty("ignore")) ? bp.ignore : "",
-                        condition: (bp.hasOwnProperty("cond")) ? bp.cond : "",
+                        ignoreCount: (bp.hasOwnProperty("ignore")) ? bp.ignore : undefined,
+                        condition: (bp.hasOwnProperty("cond")) ? bp.cond : undefined,
                         enabled: (bp.enabled == "y")? true : false,
                         text: bp.file
                     });
-                }));
+                });
+                callback(null, bps);
             });
         }
 

--- a/debuggers/gdb/gdbdebugger.js
+++ b/debuggers/gdb/gdbdebugger.js
@@ -83,7 +83,7 @@ define(function(require, exports, module) {
                 }
 
                 return new Variable({
-                   ref: variable.name,
+                   ref: (variable.objname) ? variable.objname : variable.name,
                    name: (variable.exp) ? variable.exp : variable.name,
                    value: variable.value,
                    type: variable.type,
@@ -528,7 +528,6 @@ define(function(require, exports, module) {
         function setVariable(variable, parents, value, frame, callback) {
             var args = {
                 "name": variable.ref,
-                "complex": (variable.parent.tagName == "variable"),
                 "val": value
             };
             sendCommand('setvar', args, function(err, reply) {

--- a/debuggers/gdb/gdbdebugger.js
+++ b/debuggers/gdb/gdbdebugger.js
@@ -190,8 +190,8 @@ define(function(require, exports, module) {
             sendCommand(command, {}, function(err, reply) {
                 if (err)
                     return callback && callback(err);
-                if (reply.status !== 'undefined')
-                    setState(reply.status);
+
+                setState(reply.state);
                 callback && callback();
             });
         }
@@ -236,7 +236,7 @@ define(function(require, exports, module) {
 
             // generate an error if the command did not complete successfully
             var err = null;
-            if (!content.hasOwnProperty("state") || content.state != "done") {
+            if (!content.hasOwnProperty("state") || content.state == "error") {
                 var str = "Command " + commands[content._id] + " failed";
                 if (content.hasOwnProperty("msg"))
                     str += content.msg;
@@ -577,9 +577,11 @@ define(function(require, exports, module) {
                         id: bp.number,
                         path: bp.fullname,
                         line: parseInt(bp.line, 10)-1,
-                        ignoreCount: (bp.hasOwnProperty("ignore")) ? bp.ignore : undefined,
-                        condition: (bp.hasOwnProperty("cond")) ? bp.cond : undefined,
-                        enabled: (bp.enabled == "y")? true : false,
+                        ignoreCount: (bp.hasOwnProperty("ignore")) ?
+                                      bp.ignore : undefined,
+                        condition: (bp.hasOwnProperty("cond")) ?
+                                    bp.cond : undefined,
+                        enabled: (bp.enabled == "y") ? true : false,
                         text: bp.file
                     });
                 });

--- a/debuggers/gdb/gdbdebugger.js
+++ b/debuggers/gdb/gdbdebugger.js
@@ -42,7 +42,7 @@ define(function(require, exports, module) {
             socket,           // socket to proxy
             reader,           // messagereader object
             stack,            // always up-to-date frame stack
-            sequence_id = 10, // message sequence number (0-9 reserved by proxy)
+            sequence_id = 0,  // message sequence number
             commands = [],    // queue of commands to debugger
             callbacks = {};   // callbacks to initiate when msg returned
 

--- a/debuggers/gdb/gdbdebugger.js
+++ b/debuggers/gdb/gdbdebugger.js
@@ -511,7 +511,7 @@ define(function(require, exports, module) {
         function evaluate(expression, frame, global, disableBreak, callback) {
             sendCommand("eval", { exp: expression }, function(err, reply) {
                 if (err)
-                    return callback(err);
+                    return callback(new Error("No value"));
                 else if (typeof reply.status === "undefined")
                     return callback(new Error(reply.status.msg));
 

--- a/debuggers/gdb/gdbdebugger.js
+++ b/debuggers/gdb/gdbdebugger.js
@@ -157,6 +157,7 @@ define(function(require, exports, module) {
             emit("frameActivate", { frame: stack[0] });
 
             if (segfault) {
+                showError("GDB has detected a segmentation fault and execution has stopped!");
                 emit("exception", stack[0], new Error("Segfault!"));
                 btnResume.$ext.style.display = "none";
                 btnSuspend.$ext.style.display = "inline-block";

--- a/debuggers/gdb/gdbdebugger.js
+++ b/debuggers/gdb/gdbdebugger.js
@@ -572,15 +572,15 @@ define(function(require, exports, module) {
                 if (err)
                     return callback && callback(err);
 
-                console.log(reply);
                 callback(null, reply.BreakpointTable.body.map(function (bp) {
                     return new Breakpoint({
                         id: bp.number,
                         path: bp.fullname,
-                        line: bp.line,
+                        line: parseInt(bp.line, 10)-1,
                         ignoreCount: (bp.hasOwnProperty("ignore")) ? bp.ignore : "",
                         condition: (bp.hasOwnProperty("cond")) ? bp.cond : "",
-                        enabled: (bp.enabled == "y") ? true : false
+                        enabled: (bp.enabled == "y")? true : false,
+                        text: bp.file
                     });
                 }));
             });

--- a/debuggers/gdb/gdbdebugger.js
+++ b/debuggers/gdb/gdbdebugger.js
@@ -73,6 +73,25 @@ define(function(require, exports, module) {
          * Create a scope and variables from data received from GDB
          */
         function buildScopeVariables(frame_vars, scope_index, frame_index, vars) {
+            function buildVariable(variable, scope) {
+                var props = null;
+                if (variable.hasOwnProperty("children")) {
+                    props = [];
+                    variable.children.forEach(function(child) {
+                        props.push(buildVariable(child, scope));
+                    });
+                }
+
+                return new Variable({
+                   name: (variable.exp) ? variable.exp : variable.name,
+                   value: variable.value,
+                   type: variable.type,
+                   children: !!props,
+                   properties: props,
+                   scope: scope
+                });
+            }
+
             var scope = new Scope({
                 index: scope_index,
                 type: SCOPES[scope_index],
@@ -80,12 +99,7 @@ define(function(require, exports, module) {
             });
 
             for (var i = 0, j = vars.length; i < j; i++) {
-                frame_vars.push(new Variable({
-                    name: vars[i].name,
-                    value: vars[i].value,
-                    type: vars[i].type,
-                    scope: scope
-                }));
+                frame_vars.push(buildVariable(vars[i], scope));
             }
         }
 

--- a/debuggers/gdb/gdbdebugger.js
+++ b/debuggers/gdb/gdbdebugger.js
@@ -83,6 +83,7 @@ define(function(require, exports, module) {
                 }
 
                 return new Variable({
+                   ref: variable.name,
                    name: (variable.exp) ? variable.exp : variable.name,
                    value: variable.value,
                    type: variable.type,
@@ -526,7 +527,8 @@ define(function(require, exports, module) {
 
         function setVariable(variable, parents, value, frame, callback) {
             var args = {
-                "name": variable.name,
+                "name": variable.ref,
+                "complex": (variable.parent.tagName == "variable"),
                 "val": value
             };
             sendCommand('setvar', args, function(err, reply) {

--- a/debuggers/gdb/netproxy.js
+++ b/debuggers/gdb/netproxy.js
@@ -577,12 +577,12 @@ function GDB() {
 
                 // rebuild from cache
                 frame.args = [];
-                for (var i = 0; i < cache.args.length; i++)
-                    frame.args.push(this.varcache[cache.args[i]]);
+                for (var j = 0; j < cache.args.length; j++)
+                    frame.args.push(this.varcache[cache.args[j]]);
 
                 frame.locals = [];
-                for (var i = 0; i < cache.locals.length; i++)
-                    frame.locals.push(this.varcache[cache.locals[i]]);
+                for (var j = 0; j < cache.locals.length; j++)
+                    frame.locals.push(this.varcache[cache.locals[j]]);
             }
 
             this._recurseVars();

--- a/debuggers/gdb/netproxy.js
+++ b/debuggers/gdb/netproxy.js
@@ -710,10 +710,11 @@ function GDB() {
 
         if (cause == "signal-received")
             this._updateState((state.status['signal-name']=="SIGSEGV"), thread);
-        else if (cause === "function-finished")
-            // automatically go to next line on step out
+        else if (cause === "function-finished" && state.status.hasOwnProperty("gdb-result-var"))
+            // automatically go to next line on step out of non-void function
             this.issue("-exec-next");
-        else if (cause === "breakpoint-hit" || cause === "end-stepping-range")
+        else if (cause === "breakpoint-hit" || cause === "end-stepping-range" ||
+                 cause === "function-finished")
             // update GUI state at breakpoint or after a step in/out
             this._updateState(false, thread);
         else if (cause === "exited-normally")

--- a/debuggers/gdb/netproxy.js
+++ b/debuggers/gdb/netproxy.js
@@ -23,7 +23,7 @@ var MAX_RETRY = 300;
 var client = null, // Client class instance with connection to browser
     gdb = null;    // GDB class instance with spawned gdb process
 
-var DEBUG = true;
+var DEBUG = false;
 
 var old_console = console.log;
 var log_file = null;

--- a/debuggers/gdb/netproxy.js
+++ b/debuggers/gdb/netproxy.js
@@ -766,9 +766,6 @@ function GDB() {
 
         if (cause == "signal-received")
             this._updateState((state.status['signal-name']=="SIGSEGV"), thread);
-        else if (cause === "function-finished" && state.status.hasOwnProperty("gdb-result-var"))
-            // automatically go to next line on step out of non-void function
-            this.issue("-exec-next");
         else if (cause === "breakpoint-hit" || cause === "end-stepping-range" ||
                  cause === "function-finished")
             // update GUI state at breakpoint or after a step in/out

--- a/debuggers/gdb/netproxy.js
+++ b/debuggers/gdb/netproxy.js
@@ -85,9 +85,7 @@ function Client(c) {
             }
         });
 
-        this.connection.on("error", function(e) {
-            log(e);
-        });
+        this.connection.on("error", log);
 
         this.connection.on("end", function() {
             this.connection = null;

--- a/debuggers/gdb/netproxy.js
+++ b/debuggers/gdb/netproxy.js
@@ -694,10 +694,7 @@ function GDB() {
                 break;
 
             case "setvar":
-                if (command.complex)
-                    this.post(id, "-var-assign", command.name + " " + command.val);
-                else
-                    this.post(id, "set variable", command.name + "=" + command.val);
+                this.post(id, "-var-assign", command.name + " " + command.val);
                 break;
 
             case "bp-change":
@@ -768,7 +765,7 @@ function GDB() {
                 break;
 
             case "detach":
-                this.post(id, "monitor", "exit", function() {
+                this.issue("monitor", "exit", function() {
                     log("shutdown requested");
                     process.exit();
                 });

--- a/debuggers/gdb/netproxy.js
+++ b/debuggers/gdb/netproxy.js
@@ -318,7 +318,7 @@ function GDB() {
     this._parseStateArgs = function(args) {
         /* This is crazy but GDB almost provides a JSON output */
         args = args.replace(/=(?=["|{|\[])/g, '!:');
-        args = args.replace(/([a-zA-Z0-9-]*)!:/g, "\"$1\":");
+        args = args.replace(/([a-zA-Z0-9-_]*)!:/g, "\"$1\":");
 
         /* Remove array labels */
         args = this._removeArrayLabels(args);

--- a/debuggers/gdb/netproxy.js
+++ b/debuggers/gdb/netproxy.js
@@ -704,10 +704,14 @@ function GDB() {
 
         if (cause == "signal-received")
             this._updateState((state.status['signal-name']=="SIGSEGV"), thread);
-        else if (cause === "breakpoint-hit" || cause === "end-stepping-range"
-                 || cause === "function-finished")
+        else if (cause === "function-finished")
+            // automatically go to next line on step out
+            this.issue("-exec-next");
+        else if (cause === "breakpoint-hit" || cause === "end-stepping-range")
+            // update GUI state at breakpoint or after a step in/out
             this._updateState(false, thread);
         else if (cause === "exited-normally")
+            // program has quit
             process.exit();
         else if (this.abortStepIn > 0 && state.state === "stopped") {
             // sometimes gdb does not auto-advance. if this stop matches the

--- a/debuggers/gdb/netproxy.js
+++ b/debuggers/gdb/netproxy.js
@@ -664,8 +664,7 @@ function GDB() {
         var command = this.command_queue.shift();
 
         if (typeof command.command === "undefined") {
-            log('PROXY: Received empty request from plugin');
-            console.log("ERROR: Please try re-running the debugger.");
+            console.log("ERROR: Received an empty request, ignoring.");
         }
 
         if (typeof command._id !== "number")
@@ -692,7 +691,10 @@ function GDB() {
                 break;
 
             case "setvar":
-                this.issue(id, "set variable", command.name + "=" + command.val);
+                if (command.complex)
+                    this.issue(id, "-var-assign", command.name + " " + command.val);
+                else
+                    this.issue(id, "set variable", command.name + "=" + command.val);
                 break;
 
             case "bp-change":

--- a/debuggers/gdb/netproxy.js
+++ b/debuggers/gdb/netproxy.js
@@ -187,6 +187,7 @@ function GDB() {
     this.clientReconnect = false;
     this.memoized_files = [];
     this.command_queue = [];
+    this.fullname = "";
 
     // spawn gdb proc
     this.proc = spawn('gdb', ['-q', '--interpreter=mi2'], {
@@ -278,8 +279,20 @@ function GDB() {
                 // connected! set eval of conditional breakpoints on server
                 this.issue("set breakpoint", "condition-evaluation host");
 
-                // finally, load symbol file
-                this.issue("-file-exec-and-symbols", executable, callback);
+                // load symbol file
+                this.issue("-file-exec-and-symbols", executable, function(reply) {
+                    if (reply.state != "done")
+                        return callback(reply, "Cannot load symbol file");
+
+                    // ask gdb for source location (this may be unnecessary)
+                    this.issue("-file-list-exec-source-file", null, function(reply) {
+                        if (reply.state != "done")
+                            return callback(reply, "Cannot find source file");
+
+                        this.fullname = reply.status.fullname;
+                        callback();
+                    }.bind(this));
+                }.bind(this));
             }.bind(this));
         }.bind(this));
     };
@@ -461,6 +474,9 @@ function GDB() {
 
             // provide relative path of script to IDE
             for (var i = 0, j = this.state.frames.length; i < j; i++) {
+                if (!this.state.frames[i].hasOwnProperty("fullname"))
+                    this.state.frames[i].fullname = this.fullname;
+
                 var file = this.state.frames[i].fullname;
 
                 // remember if we can view the source for this frame
@@ -472,7 +488,7 @@ function GDB() {
                 }
 
                 // we must abort step if we cannot show source for this function
-                if (!this.memoized_files[file].exists) {
+                if (!this.memoized_files[file].exists && !this.state.segfault) {
                     this.abortStepIn = this.state.frames[i+1].line;
                     this.state = {};
                     this.issue("-exec-finish");

--- a/debuggers/gdb/netproxy.js
+++ b/debuggers/gdb/netproxy.js
@@ -478,6 +478,7 @@ function GDB() {
             if (this.varcache.hasOwnProperty(key))
                 keys.push(key);
         }
+        this.varcache = {};
 
         function __flush(varobjs) {
             // once we've run out of keys, resume state compilation

--- a/debuggers/gdb/netproxy.js
+++ b/debuggers/gdb/netproxy.js
@@ -180,7 +180,6 @@ function Client(c) {
 function GDB() {
     this.sequence_id = 0;
     this.callbacks = {};
-    this.abortStepIn = false;
     this.state = {};
     this.framecache = {};
     this.varcache = {};
@@ -509,7 +508,6 @@ function GDB() {
 
                 // we must abort step if we cannot show source for this function
                 if (!this.memoized_files[file].exists && !this.state.segfault) {
-                    this.abortStepIn = this.state.frames[i+1].line;
                     this.state = {};
                     this.issue("-exec-finish");
                     return;
@@ -715,17 +713,6 @@ function GDB() {
         else if (cause === "exited-normally")
             // program has quit
             process.exit();
-        else if (this.abortStepIn > 0 && state.state === "stopped") {
-            // sometimes gdb does not auto-advance. if this stop matches the
-            // prior step-in, let's advance
-            if (state.status.frame.line == this.abortStepIn) {
-                this.issue("-exec-next");
-            }
-            else {
-                this.abortStepIn = false;
-                this._updateState(false, thread);
-            }
-        }
     };
 
     // handle a line of stdout from gdb

--- a/debuggers/gdb/netproxy.js
+++ b/debuggers/gdb/netproxy.js
@@ -276,14 +276,11 @@ function GDB() {
                 if (reply.state != "connected")
                     return callback(reply, "Cannot connect to gdbserver");
 
-                // connected! set evaluation of conditional breakpoints on server
-                this.issue("set breakpoint", "condition-evaluation target", function(reply) {
-                    if (reply.state != "done")
-                        return callback(reply, "Settings error");
+                // connected! set eval of conditional breakpoints on server
+                this.issue("set breakpoint", "condition-evaluation target");
 
-                    // finally, load symbol file
-                    this.issue("-file-exec-and-symbols", executable, callback);
-                }.bind(this));
+                // finally, load symbol file
+                this.issue("-file-exec-and-symbols", executable, callback);
             }.bind(this));
         }.bind(this));
     };

--- a/debuggers/gdb/netproxy.js
+++ b/debuggers/gdb/netproxy.js
@@ -270,11 +270,11 @@ function GDB() {
             if (retries < 0)
                 return callback(null, "Waited for gdbserver beyond timeout");
 
-            var cmd = "sleep 1 && lsof -i :"+gdb_port+" -sTCP:LISTEN|grep -q gdbserver";
-            exec(cmd, function(err) {
+            // determine if gdbserver has opened the port yet
+            exec("lsof -i :"+gdb_port+" -sTCP:LISTEN|grep -q gdbserver", function(err) {
                 // if we get an error code back, gdbserver is not yet running
                 if (err !== null)
-                    return wait.call(this, --retries, callback);
+                    return setTimeout(wait.bind(this, --retries, callback), 1000);
 
                 // success! load gdb and connect to server
                 this.spawn();

--- a/debuggers/gdb/netproxy.js
+++ b/debuggers/gdb/netproxy.js
@@ -278,7 +278,7 @@ function GDB() {
                     return callback(reply, "Cannot connect to gdbserver");
 
                 // connected! set eval of conditional breakpoints on server
-                this.issue("set breakpoint", "condition-evaluation target");
+                this.issue("set breakpoint", "condition-evaluation host");
 
                 // finally, load symbol file
                 this.issue("-file-exec-and-symbols", executable, callback);

--- a/debuggers/gdb/netproxy.js
+++ b/debuggers/gdb/netproxy.js
@@ -592,7 +592,6 @@ function GDB() {
             case 'finish':
                 this.running = true;
                 this.issue(id, "-exec-" + command.command);
-                //this._updateState();
                 break;
 
             case "setvar":

--- a/variables.js
+++ b/variables.js
@@ -22,7 +22,7 @@ define(function(require, exports, module) {
         /***** Initialization *****/
         
         var plugin = new DebugPanel("Ajax.org", main.consumes, {
-            caption: "Scope Variables",
+            caption: "Local Variables",
             index: 300
         });
         var emit = plugin.getEmitter();


### PR DESCRIPTION
Major revision of the GDB debugger with many aspects rewritten and improved to make the GDB debugger much more usable. For instance:
- Proper conditional breakpoint handling
- Revamped connection handling for better disconnect/reconnect support, including true breakpoint syncing between proxy and plugin
- Support for complex data types in the Scope Variable pane including pointers, arrays, structs, enums, and so on, including recursively- and circularly-defined objects
- Improved performance through caching and disabling certain debug code
- Protection against and better user notification for stack overflows, program environment corruption, and GDB unexpectedly quitting
- Many bug fixes including fixing race conditions during construction of the debug process, reduced instances of orphaned debugging processes, and others.

This overhauled code should allow for smaller and more digestible PRs in the future to target individual issues as we find them.

There are a couple of known issues for some corner cases but we will work on these over time. There is one pending bug that we have not been able to figure out, though: Despite much improved code for reconnects, the debugger seems to disconnect when a user closes their browser tab containing the workspace and re-opens the workspace. This disconnect does not happen if we simply reload the page. In the case of a closed and reopened tab, the reconnection happens successfully and the user can operate the debugger for a few seconds, but it seems like some timeout occurs because the connection will suddenly die and the entire debug process is dismantled. I'm hoping this is a simple fix, but I'm unsure what might be causing the timeout. Any clues?
