### PR TITLE
change "Scope Variables" caption to the more common "Local Variables"

### DIFF
--- a/variables.js
+++ b/variables.js
@@ -22,7 +22,7 @@ define(function(require, exports, module) {
         /***** Initialization *****/
         
         var plugin = new DebugPanel("Ajax.org", main.consumes, {
-            caption: "Scope Variables",
+            caption: "Local Variables",
             index: 300
         });
         var emit = plugin.getEmitter();


### PR DESCRIPTION
The Debugger UI shows the text “Scope Variables” to represent local variables. From a pedagogical standpoint, this is not a phrase that’s used very often and we wouldn’t want students to leave our class with the wrong phrase in mind. While we might be able to override the text only for our own workspaces, we wonder if this change might also benefit the core plugins. Is there a phrase other than Scope Variables (like the suggested "Local Variables") that might be more applicable? Perhaps, if not "Local Variables", then "Variables in Scope"?

Though, for the GDB Debugger, the variables displayed in this panel are truly Local, since it _only_ shows variables in the currently selected call stack frame. I suspect V8 works in a similar way.
