### PR TITLE
Rename captions for consistency

### DIFF
--- a/callstack.js
+++ b/callstack.js
@@ -49,7 +49,7 @@ define(function(require, exports, module) {
             modelSources.$sortNodes = false;
             
             modelFrames = new TreeData();
-            modelFrames.emptyMessage = "No callstack to display";
+            modelFrames.emptyMessage = "No call stack to display";
             modelFrames.$sortNodes = false;
             
             modelFrames.$sorted = false;

--- a/variables.js
+++ b/variables.js
@@ -39,7 +39,7 @@ define(function(require, exports, module) {
             model.emptyMessage = "No variables to display";
             
             model.columns = [{
-                caption: "Property",
+                caption: "Variable",
                 value: "name",
                 defaultValue: "Scope",
                 width: "40%",


### PR DESCRIPTION
This simple PR is meant to correct two inconsistencies: 
1. Empty "Call stack" panel said "callstack" even when the term "call stack" is used elsewhere. 
2. Similarly, the "Local Variables" panel listed a column name of "Property" instead of "Variable"
