### PR TITLE
Bug fix: use correct action name for "insert" action

### DIFF
--- a/breakpoints.js
+++ b/breakpoints.js
@@ -740,7 +740,7 @@ define(function(require, exports, module) {
 
                 var len, firstRow;
                 len = delta.end.row - delta.start.row;
-                if (delta.action == "insertText") {
+                if (delta.action == "insert") {
                     firstRow = delta.start.column
                         ? delta.start.row + 1
                         : delta.start.row;


### PR DESCRIPTION
The logic that updates breakpoint positions in the code editor has a small bug (uses action name "insertText" instead of "insert"). When the user presses enter in the middle of the line, the breakpoint is not supposed to move, but it does, because of this bug.
