### PR TITLE
Reference to process being debugged gets overwritten

### DIFF
--- a/debuggers/debugger.js
+++ b/debuggers/debugger.js
@@ -562,7 +562,7 @@ define(function(require, exports, module) {
             
             options.deferred = true;
             
-            process = run.run(runner, options, name, function(err, pid){
+            var process = run.run(runner, options, name, function(err, pid){
                 if (err) return callback(err);
                 
                 if (!process || process.running < process.STARTING)


### PR DESCRIPTION
This fixes the following defect:
- Create two Node scripts.
- Set a breakpoint in the first one and run it.
- While the first one is stopped at the breakpoint, run the second script - it will automatically run in non-debug mode because the debugger is already active.
- Once the second script has finished, toggle on the debug button in its output pane.
- Run the second process again (the first one should still be at the breakpoint).
- When the IDE asks "Would you like to stop the current debugger process?", click "Stop current process".

**Expected:** the first process is stopped, and the debugger attaches to the second process instead.
**Actual:** the first process is not stopped (it is still paused at the breakpoint), and the second process fails to start because the debug port is already in use.

The cause of the defect is:
- `debugger.js` keeps a reference to the process being debugged in the `process` variable.
- When a new process is started, the `doRun` function overwrites this reference with the new process, even if the new process is not run in debug mode.
- When the debugger tries to stop the active debug session, the `process` variable no longer references the process being debugged, so it does not get stopped.

My fix is to put the reference to the new process created in `doRun` in a separate local variable. When the debugger actually attaches to this process, this reference gets put into the global `process` variable in the `debug` function anyway, so everything continues to work (see https://github.com/c9/c9.ide.run.debug/blob/master/debuggers/debugger.js#L600).
