### PR TITLE
GDB explicitly preserve varcache invariant

### DIFF
--- a/debuggers/gdb/netproxy.js
+++ b/debuggers/gdb/netproxy.js
@@ -607,8 +607,10 @@ function GDB() {
                     continue;
                 }
 
-                if (this.varcache[obj.name])
-                    continue; // TODO why?
+                if (!this.varcache[obj.name]) {
+                    console.log("FATAL: varcache miss for varobj " + obj.name);
+                    process.exit(1);
+                }
 
                 this.varcache[obj.name].value = obj.value;
 


### PR DESCRIPTION
The existing code prevents variable values to update when stepping, which will cause many values to be incorrect in the debugger UI.

From a discussion with @nightwing we realized that we should instead protect the assumption that the varcache holds all variable objects, which is the change proposed here. [See discussion here](https://github.com/c9/c9.ide.run.debug/commit/da12eceb834b6c6b82a7e23602d3696e335951d4) for additional context.
