### PR TITLE
GDB refer to fullpath in bp and properly quote

### DIFF
--- a/debuggers/gdb/netproxy.js
+++ b/debuggers/gdb/netproxy.js
@@ -891,7 +891,8 @@ function GDB() {
                     args.push('"' + command.condition + '"');
                 }
 
-                args.push(command.text + ":" + (command.line + 1));
+                var path = dirname + command.path;
+                args.push('"' + path + ':' + (command.line+1) + '"');
 
                 this.post(id, "-break-insert", args.join(" "));
                 break;


### PR DESCRIPTION
This resolves two issues when setting a breakpoint with GDB:
- Properly quote paths to support spaces.
- Refer to absolute path file names. Using relative paths as we had done in the past can silently set additional breakpoints in GDB that are not visible in UI.

For example:
- create two files, `~/workspace/foo.c`, and `~/workspace/bar/foo.c`
- set a breakpoint on line X in the first, and line Y (where Y != X) in the second.
- Debug the second. The debugger will hit two breakpoints at locations X and Y, even though only one is visible in the UI (via the red dot).
