### PR TITLE
change 'Script' to 'File' in callstack caption

### DIFF
--- a/callstack.js
+++ b/callstack.js
@@ -59,7 +59,7 @@ define(function(require, exports, module) {
                 width: "60%",
                 icon: "debugger/stckframe_obj.gif"
             }, {
-                caption: "Script",
+                caption: "File",
                 value: "path",
                 width: "40%"
             }, {


### PR DESCRIPTION
With an increasing number of debuggers available, might it make more sense to use the term "File" in the call stack panel, rather than "Script"? "File" is a more generic term but could apply to both C files (in the case of the GDB debugger) and JS scripts (in the case of V8), for example.
