### PR TITLE
Remove initial slash from path in call stack file list

### DIFF
--- a/callstack.js
+++ b/callstack.js
@@ -60,7 +60,7 @@ define(function(require, exports, module) {
                 icon: "debugger/stckframe_obj.gif"
             }, {
                 caption: "Script",
-                value: "path",
+                getText: function(node) { return node.path.substr(1); },
                 width: "40%"
             }, {
                 caption: "Ln",


### PR DESCRIPTION
This PR removes the initial slash from the file path in the call stack panel. For example, whereas before it might have referred to file `/foo.c` (referencing foo.c in the user's workspace directory) it now displays `foo.c` instead.
This effectively shows a relative path from the user's workspace directory, rather than showing a slightly confusing absolute path as if the workspace directory was the root directory of the file system.
