### PR TITLE
have call stack panel respect top frame from debugger

### DIFF
--- a/callstack.js
+++ b/callstack.js
@@ -96,12 +96,13 @@ define(function(require, exports, module) {
                 function setFrames(frames, frame, force) {
                     // Load frames into the callstack and if the frames 
                     // are completely reloaded, set active frame
-                    if (loadFrames(frames, false, force) && (force 
-                      || !activeFrame || activeFrame == frame 
-                      || activeFrame == frames[0])) {
-                          
+                    var top = debug.findTopFrame(frames);
+                    if (loadFrames(frames, false, force) && (force
+                      || !activeFrame || activeFrame == frame
+                      || activeFrame == top)) {
+
                         // Set the active frame
-                        activeFrame = frames[0];
+                        activeFrame = top;
                         emit("frameActivate", { frame : activeFrame });
                         debug.activeFrame = activeFrame;
                         
@@ -121,8 +122,8 @@ define(function(require, exports, module) {
                 
                 // If we're most likely in the current frame, lets update
                 // The callstack and show it in the editor
-                var frame = frames[0];
-                if (frame && e.frame.path == frame.path 
+                var frame = debug.findTopFrame(frames);
+                if (frame && e.frame.path == frame.path
                   && e.frame.sourceId == frame.sourceId) {
                     frame.line = e.frame.line;
                     frame.column = e.frame.column;
@@ -471,7 +472,7 @@ define(function(require, exports, module) {
                 if (path == framePath || path == "/" + framePath)
                     addMarker(session, "stack", row);
 
-                var topFrame = frames[0];
+                var topFrame = debug.findTopFrame(frames);
                 if (path == topFrame.path)
                     addMarker(session, "step", topFrame.line);
             }

--- a/debuggers/debugger.js
+++ b/debuggers/debugger.js
@@ -246,7 +246,7 @@ define(function(require, exports, module) {
                             if (!err && frames.length) {
                                 emit("framesLoad", {
                                     frames: frames,
-                                    frame: frames[0]
+                                    frame: findTopFrame(frames)
                                 });
                             }
                         });
@@ -340,7 +340,7 @@ define(function(require, exports, module) {
                     if (frames.length) {
                         startDebugging({
                             frames: frames,
-                            frame: frames[0]
+                            frame: findTopFrame(frames)
                         });
                     }
                 });
@@ -418,7 +418,14 @@ define(function(require, exports, module) {
             if (debuggers[type] == debug)
                 delete debuggers[type];
         }
-        
+
+        function findTopFrame(frames) {
+            var top = frames.find(function (frame) {
+                return frame.istop;
+            });
+            return (top) ? top : frames[0];
+        }
+
         function showDebugFrame(frame, callback) {
             openFile({
                 scriptId: frame.sourceId,
@@ -1088,7 +1095,13 @@ define(function(require, exports, module) {
              * the new process.
              */
             checkAttached: checkAttached,
-            
+
+            /**
+             * Returns the topmost frame from a set of frames
+             * @param {debugger.Frame[]} frames  The stack of frames
+             */
+            findTopFrame: findTopFrame,
+
             /**
              * Displays a frame in the ace editor.
              * @param {debugger.Frame} frame  The frame to display


### PR DESCRIPTION
Makes modifications to have the debug panel respect the debugger's topmost frame in the callstack. In the past, the topmost frame that was displayed in the call stack panel was always assumed to be the top frame on the stack.

There are cases, however, when this isn't true: when using GDB to debug C, for instance, a segfault might actually occur inside a library function whose source code does not exist on the system. This causes, on segfault or break, the tabManager displays an error that the file does not exist, and the user must search the call stack to find the most relevant frame that applies in their source.

This change allows the debugger's reported top frame to be respected, and falls back to assuming the topmost frame (`frame[0]`) in other cases.
