### PR TITLE
set top frame to readable source file, fix exception event

### DIFF
--- a/debuggers/gdb/gdbdebugger.js
+++ b/debuggers/gdb/gdbdebugger.js
@@ -100,7 +100,7 @@ define(function(require, exports, module) {
         /*
          * Create a frame object, scope, and variables from a GDB frame
          */
-        function buildFrame(thread, frame, i) {
+        function buildFrame(thread, topf, frame, i) {
             var variables = [];
 
             // build scopes and variables for this frame
@@ -124,7 +124,7 @@ define(function(require, exports, module) {
                 path: "/" + frame.relative,
                 sourceId: file,
                 thread: thread,
-                istop: (i === 0),
+                istop: (i === topf),
                 variables: variables
             });
         }
@@ -143,21 +143,20 @@ define(function(require, exports, module) {
                 return detach();
             }
 
-            // no error, only frames
-            stack = [];
-
             // process frames
             var frames = content.frames;
-            for (var i = 0, j = frames.length; i < j; i++) {
-                stack.push(buildFrame(content.thread, frames[i], i));
-            }
+            var topf = Math.max(0, frames.findIndex(function (frame) {
+                return frame.exists;
+            }));
+            stack = frames.map(buildFrame.bind(this, content.thread, topf));
+            var topFrame = stack[topf];
 
             setState("stopped");
-            emit("frameActivate", { frame: stack[0] });
+            emit("frameActivate", { frame: topFrame });
 
             if (content.err === "segfault") {
                 showError("GDB has detected a segmentation fault and execution has stopped!");
-                emit("exception", stack[0], new Error("Segfault!"));
+                emit("exception", { frame: topFrame }, new Error("Segfault!"));
                 btnResume.$ext.style.display = "none";
                 btnSuspend.$ext.style.display = "inline-block";
                 btnSuspend.setAttribute("disabled", true);
@@ -166,7 +165,7 @@ define(function(require, exports, module) {
                 btnStepOver.setAttribute("disabled", true);
             }
             else {
-                emit("break", { frame: stack[0], frames: stack });
+                emit("break", { frame: topFrame, frames: stack });
                 if (stack.length == 1)
                     btnStepOut.setAttribute("disabled", true);
             }

--- a/debuggers/gdb/netproxy.js
+++ b/debuggers/gdb/netproxy.js
@@ -545,6 +545,7 @@ function GDB() {
 
                 // store relative path for IDE
                 this.state.frames[i].relative = this.memoized_files[file].relative;
+                this.state.frames[i].exists = this.memoized_files[file].exists;
             }
             this._updateStackArgs();
         }.bind(this));


### PR DESCRIPTION
This fixes two problems with segfaults when debugging using GDB:
1. The frame object in the emitted `exception` event was malformed which caused a JS error. That has now been corrected.
2. The gdbdebugger plugin now passes along the detected top frame during a break or segfault to properly highlight the stack frame in the user's code (and not attempt to open library source that does not exist on the system)

Edited to add: bullet 2, above, requires PR #30 in order to function properly
