### PR TITLE
modify frame object API to include thread id

### DIFF
--- a/data/frame.js
+++ b/data/frame.js
@@ -41,6 +41,9 @@
  * @property {String} sourcemap.path  The path of the source file where this frame is set.
  */
 /**
+ * @property {String} thread  The ID representing the thread that contains this frame.
+ */
+/**
  * @property {debugger.Variable[]} variables  The local variables in this frame.
  */
 /**
@@ -75,7 +78,7 @@ define(function(require, exports, module) {
     Frame.prototype = new Data(
         [
             "id", "index", "name", "column", "ref", "line", 
-            "path", "sourceId", "sourcemap", "istop"
+            "path", "sourceId", "sourcemap", "thread", "istop"
         ], 
         ["variables", "scopes"]
     );


### PR DESCRIPTION
Some debuggers (like GDB) may include a thread ID along with frame information. This modification to the Frame object allows debuggers to optionally store this information for use in the plugin. In the case of GDB, it is necessary to properly perform the GDB debugger plugin's evaluate() method, since the frame information must always include the thread ID.
