### PR TITLE
Allow optional callback function for cancel button in checkAttached

### DIFF
--- a/debuggers/debugger.js
+++ b/debuggers/debugger.js
@@ -684,7 +684,10 @@ define(function(require, exports, module) {
                 panels.deactivate("debugger");
         }
         
-        function checkAttached(callback) {
+        function checkAttached(callback, callbackCancel) {
+            if (callbackCancel == undefined)
+                callbackCancel = function() {};
+
             if (state != "disconnected") {
                 confirm("Debugger",
                     "The debugger is already connected to another process.",
@@ -694,9 +697,7 @@ define(function(require, exports, module) {
                             callback();
                         });
                     },
-                    function(){ // Cancel
-                        // Do Nothing
-                    },
+                    callbackCancel, // Cancel
                     { yes: "Stop current process", no: "Cancel" }
                 );
             }


### PR DESCRIPTION
This PR enables an (optional) callback to be executed if the "cancel" button is pressed when a user is asked in `checkAttached` if they wish to stop the debugger.

This should result in no change to existing code. But this enables additional functionality for us, where we assemble a debug session from the CLI and knowing if a user clicked cancel allows us to abort the session.
