### PR TITLE
logs gdbserver's stderr in debug mode only

### DIFF
--- a/debuggers/gdb/shim.js
+++ b/debuggers/gdb/shim.js
@@ -271,7 +271,7 @@ function Executable() {
         this.proc.stderr.on("end", function() {
             // dump queued stderr data, if it exists
             if (errqueue !== null) {
-                console.error(errqueue.join(""));
+                log(errqueue.join(""));
                 errqueue = null;
             }
 
@@ -284,7 +284,7 @@ function Executable() {
         function handleStderr(data) {
             // once listening, forward stderr to process
             if (this.running)
-                return process.stderr.write(data);
+                return log(data.toString());
 
             // consume and store stderr until gdbserver is listening
             var str = data.toString();


### PR DESCRIPTION
Logs `gdbserver`'s stderr in debug mode only. For simplicity, users of the debugger (e.g., students in our case) shouldn't be concerned with the internal technicalities. For example:

```
Child exited with status 0
GDBserver exiting
```

that appears on exit.
